### PR TITLE
Define string formats for dictionaries and arrays

### DIFF
--- a/src/script.odin
+++ b/src/script.odin
@@ -2,7 +2,6 @@ package bake
 
 import "core:fmt"
 import "core:strings"
-import "core:reflect"
 
 Builtin_Func :: #type proc (ctx: ^Ctx, args: []Value) -> Value
 
@@ -125,13 +124,49 @@ value_to_int :: proc(v: Value) -> (i64, bool) {
     }
 }
 
-value_to_str :: proc(value: Value) -> (string, bool) {
+value_to_str :: proc(value: Value) -> string {
     value := value_deref(value)
     #partial switch v in value {
-        case nil:    return "", true
-        case i64:    return fmt.tprint(v), true
-        case string: return v, true
-        case: return "", false
+        case nil:    return ""
+        case i64:    return fmt.tprint(v)
+        case string: return v
+        case []Value:
+            sb := strings.builder_make()
+            fmt.sbprint(&sb, "[")
+            for element, i in v {
+                if i != 0 {
+                    fmt.sbprintf(&sb, ", ")
+                }
+                if value_is_str(element) {
+                    // TODO(flysand, 2026-03-08): This needs a proper escaping
+                    // of the characters inside the string.
+                    fmt.sbprintf(&sb, "'%s'", value_to_str(element))
+                } else {
+                    fmt.sbprintf(&sb, "%s", value_to_str(element))
+                }
+            }
+            fmt.sbprint(&sb, "]")
+            return strings.to_string(sb)
+        case map[string]Value:
+            sb := strings.builder_make()
+            fmt.sbprint(&sb, "[")
+            i := 0
+            for dk, dv in v {
+                if i != 0 {
+                    fmt.sbprintf(&sb, ", ")
+                }
+                // TODO(flysand, 2026-03-08): This needs a proper escaping
+                // of the characters inside the string.
+                if value_is_str(dv) {
+                    fmt.sbprintf(&sb, "%s='%s'", dk, value_to_str(dv))
+                } else {
+                    fmt.sbprintf(&sb, "%s=%s", dk, value_to_str(dv))
+                }
+                i += 1
+            }
+            fmt.sbprint(&sb, "]")
+            return strings.to_string(sb)
+        case: unreachable()
     }
 }
 
@@ -419,11 +454,8 @@ eval_binary_op :: proc(
                 }
                 return joined[:]
             } else {
-                lhs_str, lhs_ok := value_to_str(lhs)
-                rhs_str, rhs_ok := value_to_str(rhs)
-                if !lhs_ok || !rhs_ok {
-                    script_errorf(ctx, op_loc, "Operation '+' does not work for provided types")
-                }
+                lhs_str := value_to_str(lhs)
+                rhs_str := value_to_str(rhs)
                 return fmt.tprint(lhs_str, rhs_str, sep="")
             }
         case .Div:
@@ -467,13 +499,9 @@ eval_binary_op :: proc(
                     }
                     return 1
                 } else if value_is_str(lhs) || value_is_str(rhs) {
-                    lhs_s, lhs_ok := value_to_str(lhs)
-                    rhs_s, rhs_ok := value_to_str(rhs)
-                    if lhs_ok && rhs_ok {
-                        return i64(lhs_s == rhs_s)
-                    } else {
-                        script_errorf(ctx, op_loc, "Operation '==' does not work for provided types")
-                    }
+                    lhs_s := value_to_str(lhs)
+                    rhs_s := value_to_str(rhs)
+                    return i64(lhs_s == rhs_s)
                 } else {
                     script_errorf(ctx, op_loc, "Operation '==' does not work for provided types")
                 }
@@ -498,13 +526,9 @@ eval_binary_op :: proc(
                     }
                     return 0
                 } else if value_is_str(lhs) || value_is_str(rhs) {
-                    lhs_s, lhs_ok := value_to_str(lhs)
-                    rhs_s, rhs_ok := value_to_str(rhs)
-                    if lhs_ok && rhs_ok {
-                        return i64(lhs_s != rhs_s)
-                    } else {
-                        script_errorf(ctx, op_loc, "Operation '!=' does not work for provided types")
-                    }
+                    lhs_s := value_to_str(lhs)
+                    rhs_s := value_to_str(rhs)
+                    return i64(lhs_s != rhs_s)
                 } else {
                     script_errorf(ctx, op_loc, "Operation '!=' does not work for provided types")
                 }
@@ -518,13 +542,9 @@ eval_binary_op :: proc(
             if value_is_int(lhs) && value_is_int(rhs) {
                 return i64(lhs.(i64) >= rhs.(i64))
             } else if value_is_str(lhs) || value_is_str(rhs) {
-                lhs_s, lhs_ok := value_to_str(lhs)
-                rhs_s, rhs_ok := value_to_str(rhs)
-                if lhs_ok && rhs_ok {
-                    return i64(lhs_s >= rhs_s)
-                } else {
-                    script_errorf(ctx, op_loc, "Operation '>=' does not work for provided types")
-                }
+                lhs_s := value_to_str(lhs)
+                rhs_s := value_to_str(rhs)
+                return i64(lhs_s >= rhs_s)
             } else {
                 script_errorf(ctx, op_loc, "Operation '>=' does not work for provided types")
             }
@@ -535,13 +555,9 @@ eval_binary_op :: proc(
             if value_is_int(lhs) && value_is_int(rhs) {
                 return i64(lhs.(i64) > rhs.(i64))
             } else if value_is_str(lhs) || value_is_str(rhs) {
-                lhs_s, lhs_ok := value_to_str(lhs)
-                rhs_s, rhs_ok := value_to_str(rhs)
-                if lhs_ok && rhs_ok {
-                    return i64(lhs_s > rhs_s)
-                } else {
-                    script_errorf(ctx, op_loc, "Operation '>' does not work for provided types")
-                }
+                lhs_s := value_to_str(lhs)
+                rhs_s := value_to_str(rhs)
+                return i64(lhs_s > rhs_s)
             } else {
                 script_errorf(ctx, op_loc, "Operation '>' does not work for provided types")
             }
@@ -552,13 +568,9 @@ eval_binary_op :: proc(
             if value_is_int(lhs) && value_is_int(rhs) {
                 return i64(lhs.(i64) <= rhs.(i64))
             } else if value_is_str(lhs) || value_is_str(rhs) {
-                lhs_s, lhs_ok := value_to_str(lhs)
-                rhs_s, rhs_ok := value_to_str(rhs)
-                if lhs_ok && rhs_ok {
-                    return i64(lhs_s <= rhs_s)
-                } else {
-                    script_errorf(ctx, op_loc, "Operation '<=' does not work for provided types")
-                }
+                lhs_s := value_to_str(lhs)
+                rhs_s := value_to_str(rhs)
+                return i64(lhs_s <= rhs_s)
             } else {
                 script_errorf(ctx, op_loc, "Operation '<=' does not work for provided types")
             }
@@ -569,13 +581,9 @@ eval_binary_op :: proc(
             if value_is_int(lhs) && value_is_int(rhs) {
                 return i64(lhs.(i64) < rhs.(i64))
             } else if value_is_str(lhs) || value_is_str(rhs) {
-                lhs_s, lhs_ok := value_to_str(lhs)
-                rhs_s, rhs_ok := value_to_str(rhs)
-                if lhs_ok && rhs_ok {
-                    return i64(lhs_s < rhs_s)
-                } else {
-                    script_errorf(ctx, op_loc, "Operation '<' does not work for provided types")
-                }
+                lhs_s := value_to_str(lhs)
+                rhs_s := value_to_str(rhs)
+                return i64(lhs_s < rhs_s)
             } else {
                 script_errorf(ctx, op_loc, "Operation '<' does not work for provided types")
             }
@@ -597,10 +605,7 @@ eval_binary_op :: proc(
                 }
                 return &arr[index]
             } else if value_is_map(lhs) {
-                v, ok := value_to_str(rhs)
-                if !ok {
-                    script_errorf(ctx, op_loc, "Dict subscript must be with a string")
-                }
+                v := value_to_str(rhs)
                 m := lhs.(map[string]Value)
                 if v not_in m {
                     return nil
@@ -613,8 +618,7 @@ eval_binary_op :: proc(
         case .Member:
             // TODO: error handling of type of un
             dict := lhs.(map[string]Value)
-            key, key_ok := value_to_str(rhs)
-            assert(key_ok)
+            key := value_to_str(rhs)
             if key not_in dict {
                 script_errorf(ctx, op_loc, "Key '%s' not in the dictionary", key)
             }
@@ -643,10 +647,7 @@ eval_template :: proc(ctx: ^Ctx, env: ^Env, loc: Loc, str: string) -> string {
             i += 1
             mb_val := env_get(env, str[start_idx:end_idx])
             if val, ok := mb_val.?; ok {
-                val_str, str_ok := value_to_str(val)
-                if !str_ok {
-                    script_errorf(ctx, loc, "String interpolation parameter cannot be converted to string")
-                }
+                val_str := value_to_str(val)
                 strings.write_string(&sb, val_str)
             }
         }

--- a/src/script_builtin.odin
+++ b/src/script_builtin.odin
@@ -11,11 +11,7 @@ intrinsic_assert :: proc(loc: Loc, text: string, args: []Value) {
     message := "Assertion failed."
     if len(args) == 2 {
         ok: bool
-        message, ok = value_to_str(args[1])
-        if !ok {
-            fmt.eprintfln("Assert expects a string argument")
-            os.exit(1)
-        }
+        message = value_to_str(args[1])
     }
     if !cond {
         line, col := loc_extract_line_col(loc.offs, text)
@@ -26,7 +22,7 @@ intrinsic_assert :: proc(loc: Loc, text: string, args: []Value) {
 
 builtin_print :: proc(ctx: ^Ctx, args: []Value) -> Value {
     for arg in args {
-        fmt.print(arg, sep="")
+        fmt.print(value_to_str(arg), sep="")
     }
     return nil
 }
@@ -41,10 +37,7 @@ builtin_cmd :: proc(ctx: ^Ctx, args: []Value) -> Value {
     }
     strings := make([dynamic]string)
     for arg in arr {
-        str, ok := value_to_str(arg)
-        if !ok {
-            panic("cmd(arr) One of the values doesn't cast to string")
-        }
+        str := value_to_str(arg)
         append(&strings, str)
     }
     code, err := run_cmd(strings[:])
@@ -95,25 +88,16 @@ builtin_recipe :: proc(ctx: ^Ctx, args: []Value) -> Value {
         }
         append(&cmd_arrs, make([]string, len(arr.([]Value))))
         for el, i in arr.([]Value) {
-            str, ok := value_to_str(el)
-            if !ok {
-                panic("task(cmd): Array element not castable to string")
-            }
+            str := value_to_str(el)
             cmd_arrs[idx].([]string)[i] = str
         }
     }
     for el in inputs.([]Value) {
-        str, ok := value_to_str(el)
-        if !ok {
-            panic("task(in): Array element not castable to string")
-        }
+        str := value_to_str(el)
         append(&inputs_strs, str)
     }
     for el in outputs.([]Value) {
-        str, ok := value_to_str(el)
-        if !ok {
-            panic("task(in): Array element not castable to string")
-        }
+        str := value_to_str(el)
         append(&outputs_strs, str)
     }
     append(&ctx.tasks, Recipe {
@@ -135,10 +119,7 @@ builtin_build :: proc(ctx: ^Ctx, args: []Value) -> Value {
     files_arr := files.([]Value)
     files_strs := make([dynamic]string)
     for v in files_arr {
-        str, ok := value_to_str(v)
-        if !ok {
-            panic("build(files) found a value no assignable to strings")
-        }
+        str := value_to_str(v)
         append(&files_strs, str)
     }
     build_files(ctx.tasks[:], files_strs[:])


### PR DESCRIPTION
Previously, when a dictionary or an array was supplied as the argument to the print() function, it would print these values using Odin's default formatting for arrays and maps respectively.

In order to fix this, and use bake's native formats instead, value_to_str has been rewritten to encompass all types, including arrays and dictionaries, this it's now impossible that this function would fail. This does make the language more accepting of what it allows to do, but this question will be revisited later. Then print() function uses the value_to_str() function to convert the argument into its string representation.

Fixes #9
Fixes #18