### PR TITLE
Fix: handle Stmt_Func and Builtin_Func in value_to_str to prevent unreachable() crash

### DIFF
--- a/src/script.odin
+++ b/src/script.odin
@@ -166,6 +166,10 @@ value_to_str :: proc(value: Value) -> string {
             }
             fmt.sbprint(&sb, "]")
             return strings.to_string(sb)
+        case Stmt_Func:
+            return fmt.tprint("<func ", v.name.name, ">")
+        case Builtin_Func:
+            return "<builtin>"
         case: unreachable()
     }
 }


### PR DESCRIPTION
## Summary
When a function value is converted to a string (e.g. via `print("The function is: " + a)`), the `value_to_str` procedure hits `unreachable()` because it does not recognize procedure-typed values.

## Fix
Added two new cases to the `#partial switch` in `value_to_str`:

- `case Stmt_Func`: returns `"<func name>"` (using the function's name)
- `case Builtin_Func`: returns `"<builtin>"`

## Testing
Reproduction from issue #26:
```
func a() {}
print("The function is: " + a)
```

Previously this would crash with `unreachable()`. Now it outputs `The function is: <func a>`.

Fixes #26