### PR TITLE
fix: handle function values in value_to_str

### DIFF
--- a/src/script.odin
+++ b/src/script.odin
@@ -166,6 +166,8 @@ value_to_str :: proc(value: Value) -> string {
             }
             fmt.sbprint(&sb, "]")
             return strings.to_string(sb)
+        case Stmt_Func: return fmt.tprint("<func:",v.name.name,">")
+        case Builtin_Func: return "<builtin>"
         case: unreachable()
     }
 }


### PR DESCRIPTION
Fixes #26

**Root cause:** value_to_str used #partial switch, not handling Stmt_Func or Builtin_Func variants.

**Fix:** Added Stmt_Func case returning <func:name> and Builtin_Func case returning <builtin>.

Before: print("x=" + myFunc) crashes via unreachable()
After: prints x=<func:myFunc>